### PR TITLE
chore: dockerfile nginx runner → mirror.gcr.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV CI=true
 ENV GENERATE_SOURCEMAP=false
 RUN bun run build
 
-FROM nginx:1.27-alpine AS runner
+FROM mirror.gcr.io/library/nginx:1.27-alpine AS runner
 RUN apk add --no-cache wget
 COPY --from=builder /app/build /usr/share/nginx/html
 RUN printf 'server {\n  listen 3000;\n  server_name _;\n  root /usr/share/nginx/html;\n  index index.html;\n  location / { try_files $uri $uri/ /index.html; }\n  location /health { return 200 "ok\\n"; add_header Content-Type text/plain; }\n}\n' > /etc/nginx/conf.d/default.conf


### PR DESCRIPTION
## Summary
- Switch nginx runner stage from Docker Hub `nginx:1.27-alpine` to `mirror.gcr.io/library/nginx:1.27-alpine`
- Builder already on `public.ecr.aws`; this finishes the migration
- Fleet-wide sweep after clickrise canary fix

## Test plan
- [ ] CI build succeeds on the new base
- [ ] Image pushed and ArgoCD picks it up

🤖 Generated with [Claude Code](https://claude.com/claude-code)